### PR TITLE
✨ Add login screen

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -31,15 +31,6 @@ export const setLoadingMessage = loadingMessage => ({
   loadingMessage,
 });
 
-export const setUser = (username, password) => {
-  console.log('username', username);
-  console.log('password', password);
-  return {
-    type: SET_USER,
-    username,
-    password,
-  };
-};
 export const setUser = (username, password) => ({
   type: SET_USER,
   username,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,6 +4,7 @@ export const SET_ONTOLOGIES = 'SET_ONTOLOGIES';
 export const SET_HOMEPAGE_VIEW = 'SET_HOMEPAGE_VIEW';
 export const SET_LOADING_MESSAGE = 'SET_LOADING_MESSAGE';
 export const SET_USER = 'SET_USER';
+export const CLEAR_USER = 'CLEAR_USER';
 
 export const setResources = allResources => ({
   type: SET_RESOURCES,
@@ -39,3 +40,7 @@ export const setUser = (username, password) => {
     password,
   };
 };
+
+export const clearUser = () => ({
+  type: CLEAR_USER,
+});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,6 +3,7 @@ export const SET_API = 'SET_API';
 export const SET_ONTOLOGIES = 'SET_ONTOLOGIES';
 export const SET_HOMEPAGE_VIEW = 'SET_HOMEPAGE_VIEW';
 export const SET_LOADING_MESSAGE = 'SET_LOADING_MESSAGE';
+export const SET_USER = 'SET_USER';
 
 export const setResources = allResources => ({
   type: SET_RESOURCES,
@@ -28,3 +29,13 @@ export const setLoadingMessage = loadingMessage => ({
   type: SET_LOADING_MESSAGE,
   loadingMessage,
 });
+
+export const setUser = (username, password) => {
+  console.log('username', username);
+  console.log('password', password);
+  return {
+    type: SET_USER,
+    username,
+    password,
+  };
+};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -5,6 +5,7 @@ export const SET_HOMEPAGE_VIEW = 'SET_HOMEPAGE_VIEW';
 export const SET_LOADING_MESSAGE = 'SET_LOADING_MESSAGE';
 export const SET_USER = 'SET_USER';
 export const CLEAR_USER = 'CLEAR_USER';
+export const ADD_SERVER = 'ADD_SERVER';
 
 export const setResources = allResources => ({
   type: SET_RESOURCES,
@@ -39,4 +40,9 @@ export const setUser = (username, password) => ({
 
 export const clearUser = () => ({
   type: CLEAR_USER,
+});
+
+export const addServer = url => ({
+  type: ADD_SERVER,
+  url,
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -40,6 +40,11 @@ export const setUser = (username, password) => {
     password,
   };
 };
+export const setUser = (username, password) => ({
+  type: SET_USER,
+  username,
+  password,
+});
 
 export const clearUser = () => ({
   type: CLEAR_USER,

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1,7 +1,6 @@
 .app {
   display: flex;
   flex-flow: column;
-  align-items: center;
 }
 
 .app img {

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -32,10 +32,26 @@
   margin: 0;
 }
 
+.app__header-info {
+  display: flex;
+  flex-flow: column;
+  align-items: flex-end;
+  flex: 1;
+}
+
+.app__header-user {
+  display: flex;
+  color: #fff;
+  margin-bottom: 10px;
+  align-items: center;
+}
+
+.app__header-user > * {
+  margin: 0 20px;
+}
+
 .app__header-nav {
   display: flex;
-  flex-grow: 1;
-  justify-content: flex-end;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -13,7 +13,7 @@ import './App.css';
 class App extends React.Component {
   render() {
     const authorized = !!this.props.token;
-    console.log('authorized?', authorized);
+
     return (
       <Router>
         <div className="app">

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,15 +8,18 @@ import ReduxResourceDetails from './ReduxResourceDetails';
 import ReduxOntologyHomepage from './ReduxOntologyHomepage';
 import ReduxLogin from './ReduxLogin';
 import logo from '../img/d3b-cube.svg';
-import {defaultFhirServers} from '../config';
 import './App.css';
 
 class App extends React.Component {
   render() {
-    const serverConfig = defaultFhirServers.find(
+    const serverConfig = this.props.serverOptions.find(
       x => x.url === this.props.baseUrl,
     );
-    const authorized = serverConfig.authRequired ? !!this.props.token : true;
+    if (!serverConfig) {
+      this.props.addServer(this.props.baseUrl);
+    }
+    const authorized =
+      serverConfig && serverConfig.authRequired ? !!this.props.token : true;
 
     return (
       <Router>
@@ -28,7 +31,7 @@ class App extends React.Component {
             </Link>
             {authorized ? (
               <div className="app__header-info">
-                {serverConfig.authRequired ? (
+                {serverConfig && serverConfig.authRequired ? (
                   <div className="app__header-user">
                     <p>Welcome, {this.props.username}</p>
                     <Button onClick={() => this.props.logout()}>Logout</Button>
@@ -82,11 +85,14 @@ App.propTypes = {
   token: PropTypes.string,
   username: PropTypes.string,
   logout: PropTypes.func.isRequired,
+  serverOptions: PropTypes.array,
+  addServer: PropTypes.func.isRequired,
 };
 
 App.defaultProps = {
   token: null,
   username: null,
+  serverOptions: [],
 };
 
 export default App;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {BrowserRouter as Router, Switch, Link} from 'react-router-dom';
+import {Button} from 'semantic-ui-react';
 import DecisionRoute from './DecisionRoute';
 import ReduxHomepage from './ReduxHomepage';
 import ReduxResourceDetails from './ReduxResourceDetails';
@@ -21,14 +22,22 @@ class App extends React.Component {
               <img src={logo} alt="D3b" />
               <h1>FHIR Data Dashboard</h1>
             </Link>
-            <div className="app__header-nav">
-              <Link to="/">
-                <div className="app__header-nav-item">Resources</div>
-              </Link>
-              <Link to="/ontologies">
-                <div className="app__header-nav-item">Ontologies</div>
-              </Link>
-            </div>
+            {authorized ? (
+              <div className="app__header-info">
+                <div className="app__header-user">
+                  <p>Welcome, {this.props.username}</p>
+                  <Button onClick={() => this.props.logout()}>Logout</Button>
+                </div>
+                <div className="app__header-nav">
+                  <Link to="/">
+                    <div className="app__header-nav-item">Resources</div>
+                  </Link>
+                  <Link to="/ontologies">
+                    <div className="app__header-nav-item">Ontologies</div>
+                  </Link>
+                </div>
+              </div>
+            ) : null}
           </div>
           <Switch>
             <DecisionRoute
@@ -64,10 +73,13 @@ class App extends React.Component {
 
 App.propTypes = {
   token: PropTypes.string,
+  username: PropTypes.string,
+  logout: PropTypes.func.isRequired,
 };
 
 App.defaultProps = {
   token: null,
+  username: null,
 };
 
 export default App;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,11 +8,15 @@ import ReduxResourceDetails from './ReduxResourceDetails';
 import ReduxOntologyHomepage from './ReduxOntologyHomepage';
 import ReduxLogin from './ReduxLogin';
 import logo from '../img/d3b-cube.svg';
+import {defaultFhirServers} from '../config';
 import './App.css';
 
 class App extends React.Component {
   render() {
-    const authorized = !!this.props.token;
+    const serverConfig = defaultFhirServers.find(
+      x => x.url === this.props.baseUrl,
+    );
+    const authorized = serverConfig.authRequired ? !!this.props.token : true;
 
     return (
       <Router>
@@ -24,10 +28,12 @@ class App extends React.Component {
             </Link>
             {authorized ? (
               <div className="app__header-info">
-                <div className="app__header-user">
-                  <p>Welcome, {this.props.username}</p>
-                  <Button onClick={() => this.props.logout()}>Logout</Button>
-                </div>
+                {serverConfig.authRequired ? (
+                  <div className="app__header-user">
+                    <p>Welcome, {this.props.username}</p>
+                    <Button onClick={() => this.props.logout()}>Logout</Button>
+                  </div>
+                ) : null}
                 <div className="app__header-nav">
                   <Link to="/">
                     <div className="app__header-nav-item">Resources</div>
@@ -72,6 +78,7 @@ class App extends React.Component {
 }
 
 App.propTypes = {
+  baseUrl: PropTypes.string.isRequired,
   token: PropTypes.string,
   username: PropTypes.string,
   logout: PropTypes.func.isRequired,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,13 +1,18 @@
 import React from 'react';
-import {BrowserRouter as Router, Switch, Route, Link} from 'react-router-dom';
+import PropTypes from 'prop-types';
+import {BrowserRouter as Router, Switch, Link} from 'react-router-dom';
+import DecisionRoute from './DecisionRoute';
 import ReduxHomepage from './ReduxHomepage';
 import ReduxResourceDetails from './ReduxResourceDetails';
 import ReduxOntologyHomepage from './ReduxOntologyHomepage';
+import ReduxLogin from './ReduxLogin';
 import logo from '../img/d3b-cube.svg';
 import './App.css';
 
 class App extends React.Component {
   render() {
+    const authorized = !!this.props.token;
+    console.log('authorized?', authorized);
     return (
       <Router>
         <div className="app">
@@ -26,14 +31,43 @@ class App extends React.Component {
             </div>
           </div>
           <Switch>
-            <Route path="/ontologies" component={ReduxOntologyHomepage} />
-            <Route path="/:resourceBaseType" component={ReduxResourceDetails} />
-            <Route path="/" component={ReduxHomepage} />
+            <DecisionRoute
+              path="/login"
+              renderComponent={!authorized}
+              component={ReduxLogin}
+              redirectPath="/"
+            />
+            <DecisionRoute
+              path="/ontologies"
+              renderComponent={!!authorized}
+              component={ReduxOntologyHomepage}
+              redirectPath="/login"
+            />
+            <DecisionRoute
+              path="/:resourceBaseType"
+              renderComponent={!!authorized}
+              component={ReduxResourceDetails}
+              redirectPath="/login"
+            />
+            <DecisionRoute
+              path="/"
+              renderComponent={!!authorized}
+              component={ReduxHomepage}
+              redirectPath="/login"
+            />
           </Switch>
         </div>
       </Router>
     );
   }
 }
+
+App.propTypes = {
+  token: PropTypes.string,
+};
+
+App.defaultProps = {
+  token: null,
+};
 
 export default App;

--- a/src/components/DecisionRoute.js
+++ b/src/components/DecisionRoute.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Route, Redirect} from 'react-router-dom';
+class DecisionRoute extends React.Component {
+  render() {
+    const {
+      renderComponent,
+      component: Component,
+      redirectPath,
+      ...rest
+    } = this.props;
+    console.log('this.props', this.props);
+    return (
+      <Route
+        {...rest}
+        render={props =>
+          renderComponent ? (
+            <Component {...props} />
+          ) : (
+            <Redirect
+              to={{pathname: redirectPath, state: {from: this.props.location}}}
+            />
+          )
+        }
+      />
+    );
+  }
+}
+
+DecisionRoute.propTypes = {
+  renderComponent: PropTypes.bool.isRequired,
+  component: PropTypes.elementType.isRequired,
+  redirectPath: PropTypes.string.isRequired,
+};
+
+export default DecisionRoute;

--- a/src/components/DecisionRoute.js
+++ b/src/components/DecisionRoute.js
@@ -9,7 +9,7 @@ class DecisionRoute extends React.Component {
       redirectPath,
       ...rest
     } = this.props;
-    console.log('this.props', this.props);
+
     return (
       <Route
         {...rest}

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -4,7 +4,7 @@ import {Card, Icon, Dropdown} from 'semantic-ui-react';
 import Avatar from 'react-avatar';
 import _ from 'lodash';
 import {getHumanReadableNumber} from '../utils/common';
-import {resourceCategories, defaultFhirAPIs} from '../config';
+import {resourceCategories, defaultServerDropdownOptions} from '../config';
 import SearchBar from './SearchBar';
 import SortableTable from './tables/SortableTable';
 import './Homepage.css';
@@ -212,7 +212,7 @@ class Homepage extends React.Component {
           <Dropdown
             defaultValue={this.props.baseUrl}
             selection
-            options={defaultFhirAPIs}
+            options={defaultServerDropdownOptions}
             onChange={this.selectApi}
             disabled={!this.props.allResourcesFetched}
           />

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import {Card, Icon, Dropdown} from 'semantic-ui-react';
 import Avatar from 'react-avatar';
 import _ from 'lodash';
-import {getHumanReadableNumber} from '../utils/common';
-import {resourceCategories, defaultServerDropdownOptions} from '../config';
+import {getHumanReadableNumber, getDropdownOptions} from '../utils/common';
+import {resourceCategories} from '../config';
 import SearchBar from './SearchBar';
 import SortableTable from './tables/SortableTable';
 import './Homepage.css';
@@ -212,7 +212,7 @@ class Homepage extends React.Component {
           <Dropdown
             defaultValue={this.props.baseUrl}
             selection
-            options={defaultServerDropdownOptions}
+            options={getDropdownOptions(this.props.serverOptions)}
             onChange={this.selectApi}
             disabled={!this.props.allResourcesFetched}
           />
@@ -370,6 +370,7 @@ Homepage.propTypes = {
   cardView: PropTypes.bool,
   setHomepageView: PropTypes.func.isRequired,
   loadingMessage: PropTypes.string,
+  serverOptions: PropTypes.array,
 };
 
 Homepage.defaultProps = {
@@ -377,6 +378,7 @@ Homepage.defaultProps = {
   allResourcesFetched: false,
   cardView: true,
   loadingMessage: '',
+  serverOptions: [],
 };
 
 export default Homepage;

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -4,3 +4,12 @@
   width: 100%;
   padding: 20px 20px;
 }
+
+.login .ui.input {
+  margin: 10px 0;
+}
+
+.login .ui.button {
+  width: max-content;
+  margin: 10px 0;
+}

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -1,0 +1,6 @@
+.login {
+  display: flex;
+  flex-flow: column;
+  width: 100%;
+  padding: 20px 20px;
+}

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -15,6 +15,11 @@
   border-radius: 10px;
 }
 
+.login__content form {
+  display: flex;
+  flex-flow: column;
+}
+
 .login .ui.input {
   margin: 10px 0;
 }

--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -1,8 +1,18 @@
 .login {
   display: flex;
   flex-flow: column;
-  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
   padding: 20px 20px;
+}
+
+.login__content {
+  display: flex;
+  flex-flow: column;
+  padding: 30px 30px;
+  border: 1px solid var(--d3b-blue);
+  border-radius: 10px;
 }
 
 .login .ui.input {

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Input, Button} from 'semantic-ui-react';
+import './Login.css';
+
+class Login extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: null,
+      password: null,
+    };
+  }
+
+  handleUsernameChange = e => {
+    this.setState({username: e.target.value});
+  };
+
+  handlePasswordChange = e => {
+    this.setState({password: e.target.value});
+  };
+
+  login = () => {
+    this.props.setUser(this.state.username, this.state.password);
+  };
+
+  render() {
+    console.log('this.state', this.state);
+    return (
+      <div className="login">
+        <h2>Login</h2>
+        <Input
+          placeholder="Enter your username"
+          onBlur={this.handleUsernameChange}
+        />
+        <Input
+          placeholder="Enter your password"
+          onBlur={this.handlePasswordChange}
+        />
+        <Button onClick={() => this.login()}>Login</Button>
+      </div>
+    );
+  }
+}
+
+Login.propTypes = {
+  setUser: PropTypes.func.isRequired,
+};
+
+export default Login;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -20,7 +20,8 @@ class Login extends React.Component {
     this.setState({password: e.target.value});
   };
 
-  login = () => {
+  login = e => {
+    e.preventDefault();
     this.props.setUser(this.state.username, this.state.password);
   };
 
@@ -29,15 +30,20 @@ class Login extends React.Component {
       <div className="login">
         <div className="login__content">
           <h2>Login</h2>
-          <Input
-            placeholder="Enter your username"
-            onBlur={this.handleUsernameChange}
-          />
-          <Input
-            placeholder="Enter your password"
-            onBlur={this.handlePasswordChange}
-          />
-          <Button onClick={() => this.login()}>Login</Button>
+          <form onSubmit={this.login}>
+            <Input
+              placeholder="Enter your username"
+              onChange={this.handleUsernameChange}
+              autoComplete="username"
+            />
+            <Input
+              type="password"
+              placeholder="Enter your password"
+              onChange={this.handlePasswordChange}
+              autoComplete="current-password"
+            />
+            <Button type="submit">Login</Button>
+          </form>
         </div>
       </div>
     );

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -27,16 +27,18 @@ class Login extends React.Component {
   render() {
     return (
       <div className="login">
-        <h2>Login</h2>
-        <Input
-          placeholder="Enter your username"
-          onBlur={this.handleUsernameChange}
-        />
-        <Input
-          placeholder="Enter your password"
-          onBlur={this.handlePasswordChange}
-        />
-        <Button onClick={() => this.login()}>Login</Button>
+        <div className="login__content">
+          <h2>Login</h2>
+          <Input
+            placeholder="Enter your username"
+            onBlur={this.handleUsernameChange}
+          />
+          <Input
+            placeholder="Enter your password"
+            onBlur={this.handlePasswordChange}
+          />
+          <Button onClick={() => this.login()}>Login</Button>
+        </div>
       </div>
     );
   }

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -25,7 +25,6 @@ class Login extends React.Component {
   };
 
   render() {
-    console.log('this.state', this.state);
     return (
       <div className="login">
         <h2>Login</h2>

--- a/src/components/OntologyHomepage.js
+++ b/src/components/OntologyHomepage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Dropdown} from 'semantic-ui-react';
 import {getHumanReadableNumber} from '../utils/common';
-import {defaultFhirAPIs} from '../config';
+import {defaultServerDropdownOptions} from '../config';
 import SearchBar from './SearchBar';
 import SortableTable from './tables/SortableTable';
 import './OntologyHomepage.css';
@@ -85,7 +85,7 @@ class OntologyHomepage extends React.Component {
             className="ontology-homepage__dropdown"
             defaultValue={this.props.baseUrl}
             selection
-            options={defaultFhirAPIs}
+            options={defaultServerDropdownOptions}
             onChange={this.selectApi}
             disabled={!this.props.ontologiesFetched}
           />

--- a/src/components/OntologyHomepage.js
+++ b/src/components/OntologyHomepage.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Dropdown} from 'semantic-ui-react';
-import {getHumanReadableNumber} from '../utils/common';
-import {defaultServerDropdownOptions} from '../config';
+import {getHumanReadableNumber, getDropdownOptions} from '../utils/common';
 import SearchBar from './SearchBar';
 import SortableTable from './tables/SortableTable';
 import './OntologyHomepage.css';
@@ -85,7 +84,7 @@ class OntologyHomepage extends React.Component {
             className="ontology-homepage__dropdown"
             defaultValue={this.props.baseUrl}
             selection
-            options={defaultServerDropdownOptions}
+            options={getDropdownOptions(this.props.serverOptions)}
             onChange={this.selectApi}
             disabled={!this.props.ontologiesFetched}
           />
@@ -118,12 +117,14 @@ OntologyHomepage.propTypes = {
   ontologiesFetched: PropTypes.bool,
   getOntologies: PropTypes.func.isRequired,
   loadingMessage: PropTypes.string,
+  serverOptions: PropTypes.array,
 };
 
 OntologyHomepage.defaultProps = {
   ontologies: {},
   ontologiesFetched: false,
   loadingMessage: '',
+  serverOptions: [],
 };
 
 export default OntologyHomepage;

--- a/src/components/ReduxApp.js
+++ b/src/components/ReduxApp.js
@@ -1,11 +1,17 @@
 import {connect} from 'react-redux';
+import {clearUser} from '../actions';
 import App from './App';
 
 const mapStateToProps = (state, ownProps) => ({
   token: state.user ? state.user.token : null,
+  username: state.user ? state.user.username : null,
 });
 
-const mapDispatchToProps = (dispatch, ownProps) => ({});
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    logout: () => dispatch(clearUser()),
+  };
+};
 
 const ReduxApp = connect(mapStateToProps, mapDispatchToProps)(App);
 export default ReduxApp;

--- a/src/components/ReduxApp.js
+++ b/src/components/ReduxApp.js
@@ -5,6 +5,7 @@ import App from './App';
 const mapStateToProps = (state, ownProps) => ({
   token: state.user ? state.user.token : null,
   username: state.user ? state.user.username : null,
+  baseUrl: state.resources ? state.resources.baseUrl : '',
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/components/ReduxApp.js
+++ b/src/components/ReduxApp.js
@@ -1,0 +1,11 @@
+import {connect} from 'react-redux';
+import App from './App';
+
+const mapStateToProps = (state, ownProps) => ({
+  token: state.user ? state.user.token : null,
+});
+
+const mapDispatchToProps = (dispatch, ownProps) => ({});
+
+const ReduxApp = connect(mapStateToProps, mapDispatchToProps)(App);
+export default ReduxApp;

--- a/src/components/ReduxApp.js
+++ b/src/components/ReduxApp.js
@@ -1,16 +1,18 @@
 import {connect} from 'react-redux';
-import {clearUser} from '../actions';
+import {clearUser, addServer} from '../actions';
 import App from './App';
 
 const mapStateToProps = (state, ownProps) => ({
   token: state.user ? state.user.token : null,
   username: state.user ? state.user.username : null,
   baseUrl: state.resources ? state.resources.baseUrl : '',
+  serverOptions: state.user ? state.user.serverOptions : [],
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     logout: () => dispatch(clearUser()),
+    addServer: url => dispatch(addServer(url)),
   };
 };
 

--- a/src/components/ReduxHomepage.js
+++ b/src/components/ReduxHomepage.js
@@ -78,6 +78,7 @@ const mapStateToProps = (state, ownProps) => ({
   baseUrl: state.resources.baseUrl,
   cardView: state.resources.cardView,
   loadingMessage: state.resources.loadingMessage,
+  serverOptions: state.user ? state.user.serverOptions : [],
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/components/ReduxLogin.js
+++ b/src/components/ReduxLogin.js
@@ -1,0 +1,14 @@
+import {connect} from 'react-redux';
+import {setUser} from '../actions';
+import Login from './Login';
+
+const mapStateToProps = (state, ownProps) => ({});
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    setUser: (username, password) => dispatch(setUser(username, password)),
+  };
+};
+
+const ReduxLogin = connect(mapStateToProps, mapDispatchToProps)(Login);
+export default ReduxLogin;

--- a/src/components/ReduxLogin.js
+++ b/src/components/ReduxLogin.js
@@ -1,11 +1,16 @@
 import {connect} from 'react-redux';
+import {userIsAuthorized} from '../utils/api';
 import {setUser} from '../actions';
 import Login from './Login';
 
-const mapStateToProps = (state, ownProps) => ({});
+const mapStateToProps = (state, ownProps) => ({
+  baseUrl: state.resources.baseUrl,
+});
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
+    checkUser: async (username, password, url) =>
+      await userIsAuthorized(username, password, url).then(result => result),
     setUser: (username, password) => dispatch(setUser(username, password)),
   };
 };

--- a/src/components/ReduxOntologyHomepage.js
+++ b/src/components/ReduxOntologyHomepage.js
@@ -25,6 +25,7 @@ const mapStateToProps = (state, ownProps) => ({
     state && state.ontologies ? state.ontologies.ontologiesFetched : false,
   baseUrl: state.resources.baseUrl,
   loadingMessage: state.resources.loadingMessage,
+  serverOptions: state.user ? state.user.serverOptions : [],
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,23 @@
 export const mobileWidth = 425;
 export const tabletWidth = 768;
 
-export const defaultFhirAPIs = [
-  {key: 'HAPI', text: 'HAPI', value: 'http://hapi.fhir.org/baseR4/'},
-  {key: 'Kids First', text: 'Kids First', value: 'http://10.10.1.191:8000/'},
+export const defaultFhirServers = [
+  {
+    name: 'HAPI',
+    url: 'http://hapi.fhir.org/baseR4/',
+    authRequired: false,
+  },
+  {
+    name: 'Kids First',
+    url: 'http://10.10.1.191:8000/',
+    authRequired: true,
+  },
 ];
+export const defaultServerDropdownOptions = defaultFhirServers.map(server => ({
+  key: server.name,
+  text: server.name,
+  value: server.url,
+}));
 
 export const oAuthUrl = 'https://syntheticmass.mitre.org/oauth2/accesstoken';
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,11 +13,6 @@ export const defaultFhirServers = [
     authRequired: true,
   },
 ];
-export const defaultServerDropdownOptions = defaultFhirServers.map(server => ({
-  key: server.name,
-  text: server.name,
-  value: server.url,
-}));
 
 export const oAuthUrl = 'https://syntheticmass.mitre.org/oauth2/accesstoken';
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {createStore} from 'redux';
 import rootReducer from './reducers';
-import App from './components/App';
+import ReduxApp from './components/ReduxApp';
 import 'semantic-ui-css/semantic.min.css';
 import 'react-virtualized/styles.css';
 import './index.css';
@@ -15,7 +15,7 @@ const store = createStore(
 
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <ReduxApp />
   </Provider>,
   document.getElementById('root'),
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
-import {createStore} from 'redux';
-import rootReducer from './reducers';
+import store from './store';
 import ReduxApp from './components/ReduxApp';
 import 'semantic-ui-css/semantic.min.css';
 import 'react-virtualized/styles.css';
 import './index.css';
-
-const store = createStore(
-  rootReducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
-);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,10 @@
 import {combineReducers} from 'redux';
 import resources from './resources';
 import ontologies from './ontologies';
+import user from './user';
 
 export default combineReducers({
   resources,
   ontologies,
+  user,
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,21 @@
 import {combineReducers} from 'redux';
+import {CLEAR_USER, SET_USER} from '../actions';
 import resources from './resources';
 import ontologies from './ontologies';
 import user from './user';
 
-export default combineReducers({
+const appReducer = combineReducers({
   resources,
   ontologies,
   user,
 });
+
+const rootReducer = (state, action) => {
+  if (action.type === CLEAR_USER || action.type === SET_USER) {
+    sessionStorage.removeItem('token');
+    state = undefined;
+  }
+  return appReducer(state, action);
+};
+
+export default rootReducer;

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,0 +1,19 @@
+import {SET_USER} from '../actions';
+
+const initialState = {
+  token: null,
+};
+
+const user = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_USER:
+      return {
+        ...state,
+        token: btoa(`${action.username}:${action.password}`),
+      };
+    default:
+      return state;
+  }
+};
+
+export default user;

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,6 +1,11 @@
-import {SET_USER} from '../actions';
+import {SET_USER, ADD_SERVER} from '../actions';
+import {defaultFhirServers} from '../config';
 
-const user = (state = {}, action) => {
+const initialState = {
+  serverOptions: defaultFhirServers,
+};
+
+const user = (state = initialState, action) => {
   switch (action.type) {
     case SET_USER:
       const token = btoa(`${action.username}:${action.password}`);
@@ -9,6 +14,16 @@ const user = (state = {}, action) => {
         ...state,
         token,
         username: action.username,
+      };
+    case ADD_SERVER:
+      const currentOptions = state.serverOptions;
+      return {
+        ...state,
+        serverOptions: currentOptions.concat({
+          name: 'Custom',
+          url: action.url,
+          authRequired: false,
+        }),
       };
     default:
       return {

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -20,7 +20,7 @@ const user = (state = initialState, action) => {
       return {
         ...state,
         serverOptions: currentOptions.concat({
-          name: 'Custom',
+          name: action.url,
           url: action.url,
           authRequired: false,
         }),

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,18 +1,23 @@
 import {SET_USER} from '../actions';
 
-const initialState = {
-  token: null,
-};
-
-const user = (state = initialState, action) => {
+const user = (state = {}, action) => {
   switch (action.type) {
     case SET_USER:
+      const token = btoa(`${action.username}:${action.password}`);
+      sessionStorage.setItem('token', token);
       return {
         ...state,
-        token: btoa(`${action.username}:${action.password}`),
+        token,
+        username: action.username,
       };
     default:
-      return state;
+      return {
+        ...state,
+        token: sessionStorage.getItem('token'),
+        username: sessionStorage.getItem('token')
+          ? atob(sessionStorage.getItem('token')).split(':')[0]
+          : null,
+      };
   }
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,9 @@
+import {createStore} from 'redux';
+import rootReducer from './reducers';
+
+const store = createStore(
+  rootReducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+);
+
+export default store;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -128,3 +128,22 @@ export const getReferencedBy = async (url, baseType, id) => {
   );
   return resourceReferences.filter(ref => ref.name);
 };
+
+export const userIsAuthorized = (username, password, baseUrl) => {
+  const token = btoa(`${username}:${password}`);
+  return fetch(`${baseUrl}StructureDefinition`, {
+    headers: {
+      Authorization: `Basic ${token}`,
+    },
+  })
+    .then(res => {
+      if (res.status !== 200) {
+        throw res;
+      }
+      return {isAuthorized: true, error: null};
+    })
+    .catch(error => ({
+      isAuthorized: false,
+      error,
+    }));
+};

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -70,7 +70,7 @@ export const getCapabilityStatementSearchParams = async (url, resourceType) =>
       data && data.rest && data.rest[0] && data.rest[0].resource
         ? data.rest[0].resource.find(x => x.type === resourceType)
         : [];
-    return params.searchParam ? params.searchParam : [];
+    return params && params.searchParam ? params.searchParam : [];
   });
 
 export const getOntologies = async url =>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,5 @@
 import {shouldUseProxyUrl, proxyUrl, fhirUrl} from '../config';
+import store from '../store';
 
 const fetchWithHeaders = async (url, headers, summary = false) => {
   let fullUrl = shouldUseProxyUrl(url) ? `${proxyUrl}${url}` : `${url}`;
@@ -7,13 +8,11 @@ const fetchWithHeaders = async (url, headers, summary = false) => {
       .concat(`${url.includes('?') ? '&' : '?'}`)
       .concat('_summary=count');
   }
-  const encodedStr = btoa(
-    `${process.env.REACT_APP_KF_USER}:${process.env.REACT_APP_KF_PW}`,
-  );
+  const token = store.getState().user.token;
   return fetch(`${fullUrl}`, {
     headers: {
       ...headers,
-      Authorization: `Basic ${encodedStr}`,
+      Authorization: `Basic ${token}`,
       'Cache-Control': 'max-age=3600',
     },
   })

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -3,6 +3,13 @@ import {getResourceCount, fetchAllResources} from './api';
 export const getHumanReadableNumber = value =>
   value.toLocaleString(navigator.language, {minimumFractionDigits: 0});
 
+export const getDropdownOptions = servers =>
+  servers.map(server => ({
+    key: server.name,
+    text: server.name,
+    value: server.url,
+  }));
+
 export const getBaseResourceCount = async (baseUrl, baseType, resources) => {
   let sum = 0;
   let total = await getResourceCount(`${baseUrl}${baseType}`);


### PR DESCRIPTION
Closes #19 

Adds a login screen for the user. Page will redirect to login screen until user logs in. 

🔥 Can get rid of the Netlify environment variables once this is merged.

Note: stores this info in the sessionStorage so that user can input urls (ie. refresh the page) without the Redux store state being lost. Right now there is no expiration check associated with this. When the user closes this browser tab, sessionStorage will clear.