### PR TITLE
🐛Bug fixes for demo

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,6 +2,7 @@ export const SET_RESOURCES = 'SET_RESOURCES';
 export const SET_API = 'SET_API';
 export const SET_ONTOLOGIES = 'SET_ONTOLOGIES';
 export const SET_HOMEPAGE_VIEW = 'SET_HOMEPAGE_VIEW';
+export const SET_LOADING_MESSAGE = 'SET_LOADING_MESSAGE';
 
 export const setResources = allResources => ({
   type: SET_RESOURCES,
@@ -21,4 +22,9 @@ export const setOntologies = ontologies => ({
 export const setHomepageView = cardView => ({
   type: SET_HOMEPAGE_VIEW,
   cardView,
+});
+
+export const setLoadingMessage = loadingMessage => ({
+  type: SET_LOADING_MESSAGE,
+  loadingMessage,
 });

--- a/src/components/DataPieChart.js
+++ b/src/components/DataPieChart.js
@@ -1,79 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {PieChart, Pie, Sector, ResponsiveContainer} from 'recharts';
-
-const renderActiveShape = props => {
-  const RADIAN = Math.PI / 180;
-  const {
-    cx,
-    cy,
-    midAngle,
-    innerRadius,
-    outerRadius,
-    startAngle,
-    endAngle,
-    fill,
-    payload,
-    percent,
-    value,
-  } = props;
-  const sin = Math.sin(-RADIAN * midAngle);
-  const cos = Math.cos(-RADIAN * midAngle);
-  const sx = cx + (outerRadius + 10) * cos;
-  const sy = cy + (outerRadius + 10) * sin;
-  const mx = cx + (outerRadius + 30) * cos;
-  const my = cy + (outerRadius + 30) * sin;
-  const ex = mx + (cos >= 0 ? 1 : -1) * 22;
-  const ey = my;
-  const textAnchor = cos >= 0 ? 'start' : 'end';
-
-  return (
-    <g>
-      <text x={cx} y={cy} dy={8} textAnchor="middle" fill={fill}>
-        {payload.name}
-      </text>
-      <Sector
-        cx={cx}
-        cy={cy}
-        innerRadius={innerRadius}
-        outerRadius={outerRadius}
-        startAngle={startAngle}
-        endAngle={endAngle}
-        fill={fill}
-      />
-      <Sector
-        cx={cx}
-        cy={cy}
-        startAngle={startAngle}
-        endAngle={endAngle}
-        innerRadius={outerRadius + 6}
-        outerRadius={outerRadius + 10}
-        fill={fill}
-      />
-      <path
-        d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`}
-        stroke={fill}
-        fill="none"
-      />
-      <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
-      <text
-        x={ex + (cos >= 0 ? 1 : -1) * 12}
-        y={ey}
-        textAnchor={textAnchor}
-        fill="#333"
-      >{`PV ${value}`}</text>
-      <text
-        x={ex + (cos >= 0 ? 1 : -1) * 12}
-        y={ey}
-        dy={18}
-        textAnchor={textAnchor}
-        fill="#999"
-      >
-        {`(Rate ${(percent * 100).toFixed(2)}%)`}
-      </text>
-    </g>
-  );
-};
+import {PieChart, Pie, Sector, ResponsiveContainer, Text} from 'recharts';
+import {getHumanReadableNumber} from '../utils/common';
 
 export class DataPieChart extends React.Component {
   constructor(props) {
@@ -89,13 +17,86 @@ export class DataPieChart extends React.Component {
     });
   };
 
+  renderActiveShape = props => {
+    const RADIAN = Math.PI / 180;
+    const {
+      cx,
+      cy,
+      midAngle,
+      innerRadius,
+      outerRadius,
+      startAngle,
+      endAngle,
+      fill,
+      payload,
+      percent,
+      value,
+    } = props;
+    const sin = Math.sin(-RADIAN * midAngle);
+    const cos = Math.cos(-RADIAN * midAngle);
+    const sx = cx + (outerRadius + 10) * cos;
+    const sy = cy + (outerRadius + 10) * sin;
+    const mx = cx + (outerRadius + 30) * cos;
+    const my = cy + (outerRadius + 30) * sin;
+    const ex = mx + (cos >= 0 ? 1 : -1) * 22;
+    const ey = my;
+    const textAnchor = cos >= 0 ? 'start' : 'end';
+
+    return (
+      <g>
+        <Text x={cx} y={cy} width={100} dy={8} textAnchor="middle">
+          {payload.name}
+        </Text>
+        <Sector
+          cx={cx}
+          cy={cy}
+          innerRadius={innerRadius}
+          outerRadius={outerRadius}
+          startAngle={startAngle}
+          endAngle={endAngle}
+          fill={fill}
+        />
+        <Sector
+          cx={cx}
+          cy={cy}
+          startAngle={startAngle}
+          endAngle={endAngle}
+          innerRadius={outerRadius + 6}
+          outerRadius={outerRadius + 10}
+          fill={fill}
+        />
+        <path
+          d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`}
+          stroke={fill}
+          fill="none"
+        />
+        <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+        <text
+          x={ex + (cos >= 0 ? 1 : -1) * 12}
+          y={ey}
+          textAnchor={textAnchor}
+          fill="#333"
+        >{`Total ${getHumanReadableNumber(value)}`}</text>
+        <text
+          x={ex + (cos >= 0 ? 1 : -1) * 12}
+          y={ey}
+          dy={18}
+          textAnchor={textAnchor}
+          fill="#999"
+        >
+          {`(${(percent * 100).toFixed(2)}%)`}
+        </text>
+      </g>
+    );
+  };
+
   render() {
     return (
       <ResponsiveContainer width="100%" height={300}>
         <PieChart>
           <Pie
             activeIndex={this.state.activeIndex}
-            activeShape={renderActiveShape}
+            activeShape={this.renderActiveShape}
             data={this.props.data.filter(x => x.value > 0)}
             innerRadius={60}
             outerRadius={80}

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -370,7 +370,6 @@ Homepage.propTypes = {
   cardView: PropTypes.bool,
   setHomepageView: PropTypes.func.isRequired,
   loadingMessage: PropTypes.string,
-  setLoadingMessage: PropTypes.func.isRequired,
 };
 
 Homepage.defaultProps = {

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -198,7 +198,9 @@ class Homepage extends React.Component {
       <div className="homepage">
         <div
           className={`ui ${allResourcesFetched ? 'disabled' : 'active'} loader`}
-        />
+        >
+          <p>{this.props.loadingMessage}</p>
+        </div>
         <div className="homepage__header">
           <div className="homepage__header-title">
             <h2>{searchResourceTitle}:</h2>
@@ -367,12 +369,15 @@ Homepage.propTypes = {
   setBaseUrl: PropTypes.func.isRequired,
   cardView: PropTypes.bool,
   setHomepageView: PropTypes.func.isRequired,
+  loadingMessage: PropTypes.string,
+  setLoadingMessage: PropTypes.func.isRequired,
 };
 
 Homepage.defaultProps = {
   allResources: {},
   allResourcesFetched: false,
   cardView: true,
+  loadingMessage: '',
 };
 
 export default Homepage;

--- a/src/components/OntologyHomepage.js
+++ b/src/components/OntologyHomepage.js
@@ -102,7 +102,9 @@ class OntologyHomepage extends React.Component {
         {ontologiesFetched ? (
           <SortableTable headerCells={tableHeaders} data={listOntologies} />
         ) : (
-          <div className="ui active loader" />
+          <div className="ui active loader">
+            <p>{this.props.loadingMessage}</p>
+          </div>
         )}
       </div>
     );
@@ -115,11 +117,13 @@ OntologyHomepage.propTypes = {
   setBaseUrl: PropTypes.func.isRequired,
   ontologiesFetched: PropTypes.bool,
   getOntologies: PropTypes.func.isRequired,
+  loadingMessage: PropTypes.string,
 };
 
 OntologyHomepage.defaultProps = {
   ontologies: {},
   ontologiesFetched: false,
+  loadingMessage: '',
 };
 
 export default OntologyHomepage;

--- a/src/components/ReduxHomepage.js
+++ b/src/components/ReduxHomepage.js
@@ -1,13 +1,19 @@
 import {connect} from 'react-redux';
-import {setResources, setApi, setHomepageView} from '../actions';
+import {
+  setResources,
+  setApi,
+  setHomepageView,
+  setLoadingMessage,
+} from '../actions';
 import {fetchAllResources, getResourceCount} from '../utils/api';
 import {getBaseResourceCount} from '../utils/common';
 import {acceptedResourceTypes} from '../config';
 import Homepage from './Homepage';
 
-const getAllResources = async (baseUrl, resourceType) => {
+const getAllResources = async (baseUrl, resourceType, dispatch) => {
   const url = `${baseUrl}${resourceType}`;
   let allResources = await fetchAllResources(url, []);
+  dispatch(setLoadingMessage('Getting resource totals...'));
   allResources = allResources
     ? await setResourceCounts(baseUrl, allResources)
     : [];
@@ -71,12 +77,18 @@ const mapStateToProps = (state, ownProps) => ({
     state && state.resources ? state.resources.allResourcesFetched : false,
   baseUrl: state.resources.baseUrl,
   cardView: state.resources.cardView,
+  loadingMessage: state.resources.loadingMessage,
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     fetchAllResources: async (baseUrl, resourceType) => {
-      const allResources = await getAllResources(baseUrl, resourceType);
+      dispatch(setLoadingMessage('Fetching all resources...'));
+      const allResources = await getAllResources(
+        baseUrl,
+        resourceType,
+        dispatch,
+      );
       dispatch(setResources(allResources));
     },
     setBaseUrl: url => dispatch(setApi(url)),

--- a/src/components/ReduxOntologyHomepage.js
+++ b/src/components/ReduxOntologyHomepage.js
@@ -1,5 +1,5 @@
 import {connect} from 'react-redux';
-import {setOntologies, setApi} from '../actions';
+import {setOntologies, setApi, setLoadingMessage} from '../actions';
 import {getOntologies} from '../utils/api';
 import OntologyHomepage from './OntologyHomepage';
 
@@ -24,12 +24,14 @@ const mapStateToProps = (state, ownProps) => ({
   ontologiesFetched:
     state && state.ontologies ? state.ontologies.ontologiesFetched : false,
   baseUrl: state.resources.baseUrl,
+  loadingMessage: state.resources.loadingMessage,
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     setBaseUrl: url => dispatch(setApi(url)),
     getOntologies: async url => {
+      dispatch(setLoadingMessage('Fetching all ontologies...'));
       const ontologies = await getOntologies(url);
       const groupedOntologies = groupOntologies(ontologies);
       dispatch(setOntologies(groupedOntologies));

--- a/src/components/ReduxResourceDetails.js
+++ b/src/components/ReduxResourceDetails.js
@@ -5,6 +5,7 @@ import {
   fetchResource,
   getCapabilityStatementSearchParams,
 } from '../utils/api';
+import {setLoadingMessage} from '../actions';
 import queryString from 'query-string';
 import ResourceDetails from './ResourceDetails';
 
@@ -27,6 +28,7 @@ const mapStateToProps = (state, ownProps) => {
     baseUrl: state.resources.baseUrl,
     schemaUrl: `${state.resources.baseUrl}StructureDefinition`,
     capabilityStatementUrl: `${state.resources.baseUrl}metadata`,
+    loadingMessage: state.resources.loadingMessage,
   };
 };
 
@@ -37,6 +39,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     getCapabilityStatement: (url, resourceType) =>
       getCapabilityStatementSearchParams(url, resourceType),
     fetchResource: url => fetchResource(url),
+    setLoadingMessage: message => dispatch(setLoadingMessage(message)),
   };
 };
 

--- a/src/components/ResourceDetails.js
+++ b/src/components/ResourceDetails.js
@@ -51,6 +51,7 @@ class ResourceDetails extends React.Component {
     this.setState({queriesComplete: false}, async () => {
       let total = this.state.total;
       if (!resourceFetched) {
+        this.props.setLoadingMessage(`Fetching ${resourceType} totals...`);
         let url = `${baseUrl}${resourceBaseType}`;
         if (resourceBaseType !== resourceType) {
           url = url.concat(`?_profile:below=${resourceUrl}`);
@@ -59,7 +60,9 @@ class ResourceDetails extends React.Component {
           total = await getBaseResourceCount(baseUrl, resourceBaseType);
         }
       }
+      this.props.setLoadingMessage(`Getting ${resourceType} schema...`);
       const schema = await this.getSchema();
+      this.props.setLoadingMessage(`Getting ${resourceType} attributes...`);
       const attributes = schema ? await this.getQueryParams(schema) : [];
       this.setState(
         {
@@ -70,6 +73,7 @@ class ResourceDetails extends React.Component {
           ),
         },
         () => {
+          this.props.setLoadingMessage(`Populating charts...`);
           this.setQueryResults();
         },
       );
@@ -388,6 +392,7 @@ class ResourceDetails extends React.Component {
 
   getAttributeTableResults = async (attribute, chartType) => {
     this.setState({showModal: true, tableLoaded: false}, async () => {
+      this.props.setLoadingMessage(`Fetching ${attribute.name} details...`);
       const {baseUrl, resourceBaseType, resourceType, resourceUrl} = this.props;
       let data = null;
       const allFields = defaultTableFields.concat(attribute.name);
@@ -442,9 +447,9 @@ class ResourceDetails extends React.Component {
     return (
       <div className="resource-details">
         <AppBreadcrumb history={this.props.history} />
-        <div
-          className={`ui ${queriesComplete ? 'disabled' : 'active'} loader`}
-        />
+        <div className={`ui ${queriesComplete ? 'disabled' : 'active'} loader`}>
+          <p>{this.props.loadingMessage}</p>
+        </div>
         <div className="resource-details__header">
           <div className="resource-details__header-title">
             <h2>{resourceType}:</h2>
@@ -521,9 +526,13 @@ class ResourceDetails extends React.Component {
                   nextPageUrl={this.state.nextPageUrl}
                   totalResults={this.state.totalResults}
                   tableColumns={this.state.tableColumns}
+                  loadingMessage={this.props.loadingMessage}
+                  setLoadingMessage={this.props.setLoadingMessage}
                 />
               ) : (
-                <div className="ui active loader" />
+                <div className="ui active loader">
+                  <p>{this.props.loadingMessage}</p>
+                </div>
               )}
             </Modal.Description>
           </Modal.Content>
@@ -555,6 +564,8 @@ ResourceDetails.propTypes = {
   baseUrl: PropTypes.string.isRequired,
   schemaUrl: PropTypes.string.isRequired,
   capabilityStatementUrl: PropTypes.string.isRequired,
+  loadingMessage: PropTypes.string,
+  setLoadingMessage: PropTypes.func.isRequired,
 };
 
 ResourceDetails.defaultProps = {

--- a/src/components/ResourceDetails.js
+++ b/src/components/ResourceDetails.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Modal, Header} from 'semantic-ui-react';
-import {getHumanReadableNumber} from '../utils/common';
+import {getHumanReadableNumber, getBaseResourceCount} from '../utils/common';
 import {fhirUrl, defaultTableFields} from '../config';
 import AppBreadcrumb from './AppBreadcrumb';
 import DataPieChart from './DataPieChart';
@@ -54,8 +54,10 @@ class ResourceDetails extends React.Component {
         let url = `${baseUrl}${resourceBaseType}`;
         if (resourceBaseType !== resourceType) {
           url = url.concat(`?_profile:below=${resourceUrl}`);
+          total = await this.props.getCount(url);
+        } else {
+          total = await getBaseResourceCount(baseUrl, resourceBaseType);
         }
-        total = await this.props.getCount(url);
       }
       const schema = await this.getSchema();
       const attributes = schema ? await this.getQueryParams(schema) : [];

--- a/src/components/ResourceDetails.js
+++ b/src/components/ResourceDetails.js
@@ -300,7 +300,7 @@ class ResourceDetails extends React.Component {
           concepts.push(...systemConcepts);
           return {
             ...attribute,
-            queryParams: concepts.length < 100 ? concepts : [], // how to handle large sets of parameters? very slow
+            queryParams: concepts, // how to handle large sets of parameters? very slow
           };
         } else {
           return attribute;

--- a/src/components/tables/ReferenceTable.js
+++ b/src/components/tables/ReferenceTable.js
@@ -27,6 +27,9 @@ class ReferenceTable extends React.Component {
 
   fetchReferences = async () => {
     this.setState({loadingReferences: true}, async () => {
+      this.props.setLoadingMessage(
+        `Fetching references for ${this.props.resourceId}...`,
+      );
       const references = await getReferencedBy(
         this.props.baseUrl,
         this.props.resourceType,
@@ -75,8 +78,10 @@ class ReferenceTable extends React.Component {
           className={`ui ${
             this.state.loadingReferences ? 'active' : 'disabled'
           } loader`}
-        />
-        {this.state.referenceData ? (
+        >
+          <p>{this.props.loadingMessage}</p>
+        </div>
+        {this.state.referenceData && !this.state.loadingReferences ? (
           <div>
             <h3>Resources that reference {this.props.resourceId}:</h3>
             <SortableTable
@@ -122,10 +127,13 @@ ReferenceTable.propTypes = {
   ),
   onClick: PropTypes.func,
   baseUrl: PropTypes.string.isRequired,
+  loadingMessage: PropTypes.string,
+  setLoadingMessage: PropTypes.func.isRequired,
 };
 
 ReferenceTable.defaultProps = {
   onClick: () => {},
+  loadingMessage: '',
 };
 
 export default ReferenceTable;

--- a/src/components/tables/ResultsTable.js
+++ b/src/components/tables/ResultsTable.js
@@ -257,6 +257,8 @@ class ResultsTable extends React.Component {
                   this.state.rowData ? this.state.rowData.resourceType : ''
                 }
                 baseUrl={this.props.baseUrl}
+                loadingMessage={this.props.loadingMessage}
+                setLoadingMessage={this.props.setLoadingMessage}
               />
             </Modal.Description>
           </Modal.Content>
@@ -277,6 +279,8 @@ ResultsTable.propTypes = {
   nextPageUrl: PropTypes.string,
   totalResults: PropTypes.number,
   tableColumns: PropTypes.array,
+  loadingMessage: PropTypes.string,
+  setLoadingMessage: PropTypes.func.isRequired,
 };
 
 ResultsTable.defaultProps = {
@@ -285,4 +289,5 @@ ResultsTable.defaultProps = {
   nextPageUrl: null,
   totalResults: 0,
   tableColumns: defaultTableFields,
+  loadingMessage: '',
 };

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,7 @@ h2,
 h3,
 h4,
 h5 {
+  font-family: Rubrik, Helvetica, Arial, sans-serif;
   font-weight: 500;
 }
 
@@ -69,7 +70,6 @@ pre {
   display: flex;
   flex-flow: column;
   width: 200px;
-  font-size: 12px;
 }
 
 .ui.inverted.dimmer .ui.loader.active p,

--- a/src/index.css
+++ b/src/index.css
@@ -62,3 +62,17 @@ pre {
   white-space: pre-wrap;
   word-break: break-all;
 }
+
+/* Semantic UI overrides */
+.ui.inverted.dimmer .ui.loader.active,
+.ui.loader.active {
+  display: flex;
+  flex-flow: column;
+  width: 200px;
+  font-size: 12px;
+}
+
+.ui.inverted.dimmer .ui.loader.active p,
+.ui.loader.active p {
+  margin-top: 40px;
+}

--- a/src/reducers/resources.js
+++ b/src/reducers/resources.js
@@ -1,4 +1,9 @@
-import {SET_RESOURCES, SET_API, SET_HOMEPAGE_VIEW} from '../actions';
+import {
+  SET_RESOURCES,
+  SET_API,
+  SET_HOMEPAGE_VIEW,
+  SET_LOADING_MESSAGE,
+} from '../actions';
 
 const initialState = {
   baseUrl: process.env.REACT_APP_FHIR_API
@@ -28,6 +33,11 @@ const resources = (state = initialState, action) => {
       return {
         ...state,
         cardView: action.cardView,
+      };
+    case SET_LOADING_MESSAGE:
+      return {
+        ...state,
+        loadingMessage: action.loadingMessage,
       };
     default:
       return state;

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,4 +1,4 @@
-import {getResourceCount} from './api';
+import {getResourceCount, fetchAllResources} from './api';
 
 export const getHumanReadableNumber = value =>
   value.toLocaleString(navigator.language, {minimumFractionDigits: 0});
@@ -6,18 +6,59 @@ export const getHumanReadableNumber = value =>
 export const getBaseResourceCount = async (baseUrl, baseType, resources) => {
   let sum = 0;
   let total = await getResourceCount(`${baseUrl}${baseType}`);
+  console.log('total', total);
+  console.log('baseUrl');
   const countedResources = new Set();
-  Object.keys(resources).forEach(key => {
-    if (
-      key &&
-      resources[key] &&
-      resources[key].baseType === baseType &&
-      resources[key].name !== baseType &&
-      !countedResources.has(resources[key].url)
-    ) {
-      countedResources.add(resources[key].url);
-      sum += resources[key].count;
-    }
-  });
+  if (!resources) {
+    await fetchAllResources(`${baseUrl}StructureDefinition`, []).then(
+      async data => {
+        console.log('data', data);
+        resources = await Promise.all(
+          data
+            .map(item => item.resource)
+            .filter(resource => resource && resource.type === baseType)
+            .map(async resource => {
+              console.log('getting count for resource', resource.name);
+              const count = await getResourceCount(
+                `${baseUrl}${baseType}?_profile:below=${resource.url}`,
+              );
+              console.log('count', count);
+              return {
+                ...resource,
+                count,
+              };
+            }),
+        );
+        console.log('resources', resources);
+        resources.forEach(resource => {
+          console.log('resource', resource);
+          if (
+            resource &&
+            resource.type === baseType &&
+            resource.name !== baseType &&
+            !countedResources.has(resource.url)
+          ) {
+            console.log('adding resource', resource);
+            countedResources.add(resource.url);
+            sum += resource.count;
+          }
+        });
+      },
+    );
+  } else {
+    Object.keys(resources).forEach(key => {
+      if (
+        key &&
+        resources[key] &&
+        resources[key].baseType === baseType &&
+        resources[key].name !== baseType &&
+        !countedResources.has(resources[key].url)
+      ) {
+        countedResources.add(resources[key].url);
+        sum += resources[key].count;
+      }
+    });
+  }
+  console.log('sum', sum);
   return total - sum;
 };

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -6,39 +6,31 @@ export const getHumanReadableNumber = value =>
 export const getBaseResourceCount = async (baseUrl, baseType, resources) => {
   let sum = 0;
   let total = await getResourceCount(`${baseUrl}${baseType}`);
-  console.log('total', total);
-  console.log('baseUrl');
   const countedResources = new Set();
   if (!resources) {
     await fetchAllResources(`${baseUrl}StructureDefinition`, []).then(
       async data => {
-        console.log('data', data);
         resources = await Promise.all(
           data
             .map(item => item.resource)
             .filter(resource => resource && resource.type === baseType)
             .map(async resource => {
-              console.log('getting count for resource', resource.name);
               const count = await getResourceCount(
                 `${baseUrl}${baseType}?_profile:below=${resource.url}`,
               );
-              console.log('count', count);
               return {
                 ...resource,
                 count,
               };
             }),
         );
-        console.log('resources', resources);
         resources.forEach(resource => {
-          console.log('resource', resource);
           if (
             resource &&
             resource.type === baseType &&
             resource.name !== baseType &&
             !countedResources.has(resource.url)
           ) {
-            console.log('adding resource', resource);
             countedResources.add(resource.url);
             sum += resource.count;
           }
@@ -59,6 +51,5 @@ export const getBaseResourceCount = async (baseUrl, baseType, resources) => {
       }
     });
   }
-  console.log('sum', sum);
   return total - sum;
 };


### PR DESCRIPTION
1. Fixed overflowing text in pie charts for long attribute names
2. Removed limit for querying codes so that HPO codes can be queried
3. Adding some spinner text that updates from step to step to show the user progress is being made

Notes:
1. Querying all HPO codes still shows "insufficient resources" in the console, but pie chart renders. I think it's only partial data.
2. About the base type counts - there is no way to query resources without a profile attached to them (eg. `/Patient?_profile:missing=true). So on the details page for a base resource type like Patient, even though the total may be 0, all the charts will show data from the resources that have a base type of Patient, like Individual. So the data on this page looks a little confusing, maybe this is a good talking point?