### PR TITLE
♻️Use $snapshot endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11403,16 +11403,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
-    "query-string": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.10.1.tgz",
-      "integrity": "sha512-SHTUV6gDlgMXg/AQUuLpTiBtW/etZ9JT6k6RCtCyqADquApLX0Aq5oK/s5UeTUAWBG50IExjIr587GqfXRfM4A==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -13340,11 +13330,6 @@
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg=="
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -13509,11 +13494,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
-    "query-string": "^6.10.1",
     "react": "^16.12.0",
     "react-avatar": "^3.9.0",
     "react-bootstrap": "^1.0.0-beta.16",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -77,7 +77,7 @@ class App extends React.Component {
               redirectPath="/login"
             />
             <DecisionRoute
-              path="/:resourceBaseType"
+              path="/:resourceId"
               renderComponent={!!this.isAuthorized()}
               component={ReduxResourceDetails}
               redirectPath="/login"

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -94,7 +94,7 @@ class Homepage extends React.Component {
 
   onClick = resource => {
     this.props.history.push(
-      `/${resource.baseType}?name=${resource.name}&url=${resource.url}`,
+      `/${resource.id}`,
     );
   };
 

--- a/src/components/ReduxResourceDetails.js
+++ b/src/components/ReduxResourceDetails.js
@@ -6,24 +6,18 @@ import {
   getCapabilityStatementSearchParams,
 } from '../utils/api';
 import {setLoadingMessage} from '../actions';
-import queryString from 'query-string';
 import ResourceDetails from './ResourceDetails';
 
 const mapStateToProps = (state, ownProps) => {
-  const resourceBaseType = ownProps.match.params.resourceBaseType;
-  const queryValues = queryString.parse(ownProps.location.search);
-  const resourceType = queryValues.name;
-  const resourceUrl = queryValues.url;
+  const resourceId = ownProps.match.params.resourceId;
   const hasResources =
     state && state.resources && state.resources.allResourcesFetched;
   const resource = hasResources
-    ? state.resources.allResources[resourceType]
+    ? state.resources.allResources[resourceId]
     : {};
   return {
     total: resource.count ? resource.count : 0,
-    resourceBaseType,
-    resourceType,
-    resourceUrl,
+    resourceId,
     resourceFetched: hasResources,
     baseUrl: state.app.selectedServer.url,
     schemaUrl: `${state.app.selectedServer.url}StructureDefinition`,

--- a/src/components/ResourceDetails.js
+++ b/src/components/ResourceDetails.js
@@ -120,6 +120,7 @@ class ResourceDetails extends React.Component {
   getSchema = async () => {
     const {
       resourceBaseType,
+      resourceType,
       resourceUrl,
       fetchResource,
       getSearchParams,
@@ -129,14 +130,10 @@ class ResourceDetails extends React.Component {
       capabilityStatementUrl,
     } = this.props;
     return await fetchResource(
-      `${schemaUrl}?type=${resourceBaseType}&url=${resourceUrl}`,
+      `${schemaUrl}/${resourceType}/$snapshot`,
       this.state.abortController,
     )
-      .then(async data => {
-        const schema =
-          data && data.entry && data.entry[0] && data.entry[0].resource
-            ? data.entry[0].resource
-            : null;
+      .then(async schema => {
         return await getSearchParams(
           `${baseUrl}SearchParameter?base=${resourceBaseType}`,
           this.state.abortController,
@@ -220,22 +217,19 @@ class ResourceDetails extends React.Component {
     queryableAttributes,
     snapshot = null,
   ) => {
-    const {resourceBaseType, schemaUrl} = this.props;
+    const {resourceBaseType, resourceType, schemaUrl} = this.props;
     if (!snapshot) {
       await this.props
         .fetchResource(
-          `${schemaUrl}?type=${resourceBaseType}&url=${fhirUrl}${resourceBaseType}`,
+          `${schemaUrl}/${resourceType}/$snapshot`,
           this.state.abortController,
         )
         .then(async data => {
           snapshot =
             data &&
-            data.entry &&
-            data.entry[0] &&
-            data.entry[0].resource &&
-            data.entry[0].resource.snapshot &&
-            data.entry[0].resource.snapshot.element
-              ? data.entry[0].resource.snapshot.element
+            data.snapshot &&
+            data.snapshot.element
+              ? data.snapshot.element
               : null;
         })
         .catch(err => logErrors('Error fetching snapshot:', err));


### PR DESCRIPTION
Closes #60 

switched over to using the $snapshot endpoint to get a resource's full schema instead of doing multiple requests to get the snapshot and differential separately, and then combine them.

This allows the url for a resource detail's page to just be `/:resourceId` without the extra query parameters.