### PR TITLE
♻️ Rearranging tabs on an ID detail page

### DIFF
--- a/cypress/integration/resourceIdDetails.js
+++ b/cypress/integration/resourceIdDetails.js
@@ -13,17 +13,6 @@ describe('Resource ID Details page', () => {
         'https://damp-castle-44220.herokuapp.com/http://hapi.fhir.org/baseR4/Observation/123',
       response: 'fixture:resourceIdDetails/resourceDetails.json',
     }).as('getResource');
-    cy.visit('/resources/Observation/id=123');
-    cy.wait(['@getStructureDefinition', '@getResource']);
-  });
-
-  it('loads the resource details', () => {
-    cy.url().should('include', '/resources/Observation/id=123');
-    cy.contains('Payload');
-  });
-
-  it('loads resource references', () => {
-    cy.server();
     cy.route({
       method: 'GET',
       url:
@@ -54,14 +43,24 @@ describe('Resource ID Details page', () => {
         'https://damp-castle-44220.herokuapp.com/http://hapi.fhir.org/baseR4/StructureDefinition?url=http://fhir.kids-first.io/StructureDefinition/Condition',
       response: 'fixture:resourceIdDetails/conditionStructureDefinition.json',
     }).as('getConditionSD');
-    cy.contains('References').click();
+    cy.visit('/resources/Observation/id=123');
     cy.wait([
+      '@getStructureDefinition',
+      '@getResource',
       '@getCapabilityStatementReferences',
       '@getPatientDetails',
       '@getPatientSD',
       '@getConditionDetails',
       '@getConditionSD',
     ]);
+  });
+
+  it('loads the resource details', () => {
+    cy.url().should('include', '/resources/Observation/id=123');
+    cy.contains('Payload');
+  });
+
+  it('loads resource references', () => {
     cy.get('.sortable-table')
       .eq(0)
       .children('table')

--- a/src/components/IdDetails.js
+++ b/src/components/IdDetails.js
@@ -76,24 +76,43 @@ class IdDetails extends React.Component {
       {display: 'Profile', sortId: 'profile', sort: true},
       {display: 'Total References', sortId: 'total', sort: true},
     ];
-    const secondTab = history.location.pathname.includes('/resources')
-      ? {
-          menuItem: 'References',
-          render: () => (
-            <Tab.Pane>
-              <ReferenceTable
-                resource={payload}
-                tableHeaders={tableHeaders}
-                baseUrl={this.props.baseUrl}
-                setLoadingMessage={this.props.setLoadingMessage}
-                loadingMessage={this.props.loadingMessage}
-                history={this.props.history}
-              />
-            </Tab.Pane>
-          ),
-        }
-      : null;
-    const thirdTab =
+    const firstTabs = history.location.pathname.includes('/resources')
+      ? [
+          {
+            menuItem: 'References',
+            render: () => (
+              <Tab.Pane>
+                <ReferenceTable
+                  resource={payload}
+                  tableHeaders={tableHeaders}
+                  baseUrl={this.props.baseUrl}
+                  setLoadingMessage={this.props.setLoadingMessage}
+                  loadingMessage={this.props.loadingMessage}
+                  history={this.props.history}
+                />
+              </Tab.Pane>
+            ),
+          },
+          {
+            menuItem: 'Payload',
+            render: () => (
+              <Tab.Pane>
+                <ReactJson src={payload} />
+              </Tab.Pane>
+            ),
+          },
+        ]
+      : [
+          {
+            menuItem: 'Payload',
+            render: () => (
+              <Tab.Pane>
+                <ReactJson src={payload} />
+              </Tab.Pane>
+            ),
+          },
+        ];
+    const timelineTab =
       payload.resourceType === 'Patient'
         ? {
             menuItem: 'Timeline',
@@ -122,7 +141,7 @@ class IdDetails extends React.Component {
           }
         : null;
 
-    const fourthTab =
+    const submitDataTab =
       payload.resourceType === 'Patient'
         ? {
             menuItem: 'Submit Data',
@@ -138,19 +157,8 @@ class IdDetails extends React.Component {
             ),
           }
         : null;
-    const panes = [
-      {
-        menuItem: 'Payload',
-        render: () => (
-          <Tab.Pane>
-            <ReactJson src={payload} />
-          </Tab.Pane>
-        ),
-      },
-      {...secondTab},
-      {...thirdTab},
-      {...fourthTab},
-    ];
+    const panes = firstTabs.concat(timelineTab).concat(submitDataTab);
+
     return (
       <div className="id-details">
         {this.state.loading ? (


### PR DESCRIPTION
Now when looking at a specific resource instance (ex: Patient 123), the tabs will be in the order of: References, Payload, Timeline, Submit Data