### PR TITLE
🔧 Adding NCPI to proxy url

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -55,7 +55,7 @@ export const defaultFhirServers = getDefaultFhirServers();
 export const oAuthUrl = 'https://syntheticmass.mitre.org/oauth2/accesstoken';
 
 export const shouldUseProxyUrl = url =>
-  url.includes('hapi') || url.includes('synthea');
+  url.includes('hapi') || url.includes('synthea') || url.includes('ncpi');
 
 export const proxyUrl = 'https://damp-castle-44220.herokuapp.com/';
 export const fhirUrl = 'http://hl7.org/fhir/StructureDefinition/';


### PR DESCRIPTION
this is a quick fix to ensure that the NCPI server uses a proxy url to get around CORs issues. Need to figure out how to do this at scale in the future.

Question to answer before merging this - are there security issues with this method? So far the dashboard has only used this method for HAPI and Synthea servers. I want to make sure this is okay before we use it for a server with our data in it. 